### PR TITLE
Remove windows line endings from ducky script

### DIFF
--- a/adafruit_ducky.py
+++ b/adafruit_ducky.py
@@ -132,7 +132,7 @@ class Ducky:
 
         with open(filename, "r") as duckyscript:
             for line in duckyscript:
-                self.lines.append(line[:-1])
+                self.lines.append(line[:-1].rstrip("\r"))
 
     def loop(  # pylint: disable=too-many-return-statements
         self, line: Optional[str] = None


### PR DESCRIPTION
Remove potential `\r` at the end of lines for payloads using windows formatting.
Not just a global `strip()` because we want to keep the spaces for a `STRING` command.
fixes #5 
