### PR TITLE
Fix some bugs

### DIFF
--- a/adafruit_ducky.py
+++ b/adafruit_ducky.py
@@ -141,6 +141,7 @@ class Ducky:
         if line is None:
             try:
                 line = self.lines[0]
+                line = line.strip() 
             except IndexError:
                 print("Done!")
                 return False
@@ -185,10 +186,10 @@ class Ducky:
 
             self.write_key(start)
             if len(words) == 1:
+                self.keyboard.release_all()
                 time.sleep(self.default_delay)
                 self.last = self.lines[0]
                 self.lines.pop(0)
-                self.keyboard.release_all()
                 return True
             if len(words[1]):
                 self.loop(line=words[1])
@@ -198,8 +199,8 @@ class Ducky:
 
         self.keyboard.release_all()
         time.sleep(self.default_delay)
-        self.last = self.lines[0]
-        self.lines.pop(0)
+        # self.last = self.lines[0]
+        # self.lines.pop(0)
         return True
 
     def write_key(self, start: str) -> None:


### PR DESCRIPTION
144: Fix white spaces after line
189: Prevent from key still pressed when default delay is more than zero. 
202: Prevent error index out of bound whet read last line
203: Fix an error when press multiples key that skip the next execution line. 

ducky example code: 
{
DEFAULTDELAY 1000
DELAY 5000
STRING hello world
ENTER 
CONTROL A
CONTROL C
DOWN 
CONTROL V

}