### PR TITLE
Ramsrq fixes

### DIFF
--- a/adafruit_ducky.py
+++ b/adafruit_ducky.py
@@ -141,6 +141,7 @@ class Ducky:
         if line is None:
             try:
                 line = self.lines[0]
+                line = line.strip() # Fix
             except IndexError:
                 print("Done!")
                 return False
@@ -185,10 +186,10 @@ class Ducky:
 
             self.write_key(start)
             if len(words) == 1:
+                self.keyboard.release_all() 
                 time.sleep(self.default_delay)
                 self.last = self.lines[0]
                 self.lines.pop(0)
-                self.keyboard.release_all()
                 return True
             if len(words[1]):
                 self.loop(line=words[1])
@@ -198,8 +199,8 @@ class Ducky:
 
         self.keyboard.release_all()
         time.sleep(self.default_delay)
-        self.last = self.lines[0]
-        self.lines.pop(0)
+        # self.last = self.lines[0]
+        # self.lines.pop(0)
         return True
 
     def write_key(self, start: str) -> None:

--- a/adafruit_ducky.py
+++ b/adafruit_ducky.py
@@ -141,7 +141,6 @@ class Ducky:
         if line is None:
             try:
                 line = self.lines[0]
-                line = line.strip() # Fix
             except IndexError:
                 print("Done!")
                 return False
@@ -186,7 +185,7 @@ class Ducky:
 
             self.write_key(start)
             if len(words) == 1:
-                self.keyboard.release_all() 
+                self.keyboard.release_all()
                 time.sleep(self.default_delay)
                 self.last = self.lines[0]
                 self.lines.pop(0)
@@ -199,8 +198,6 @@ class Ducky:
 
         self.keyboard.release_all()
         time.sleep(self.default_delay)
-        # self.last = self.lines[0]
-        # self.lines.pop(0)
         return True
 
     def write_key(self, start: str) -> None:


### PR DESCRIPTION
This PR supersedes #10 

I attempted to fix the formatting and one other noted change but it would not allow me to commit to the PR branch. 

I wanted to get this one merged if possible to minimize chances for merge conflicts from the other PR which touched more code than this one. 

From original PR:

> Some issues are detected when:
> 
> There are white spaces before and/or after a token when send press multiple keys
> There is a empty line at the end of the file (index out of bound)
> When default delay is modified, single or multiple key remain pressed during default delay period.
> 
> 144: Fix white spaces after line
> 189: Prevent from key still pressed when default delay is more than zero.
> 202: Prevent error index out of bound whet read last line
> 203: Fix an error when press multiples key that skip the next execution line.


I've omitted the first fix (144: Fix white spaces after line) because I was unable to replicate any issues related to that and during testing it seemed like this resulted in potentially stripping whitespace that was added intentionally by the user.

The other fixes noted in that PR are included here. 

I tested all of them successfully on a Feather S2 TFT using the simpletest code and some basic "hello world" duckyscript code.