### PR TITLE
docs: fix link to duckyscript docs and circup install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ CircuitPython library for running DuckyScript
 
 DuckyScript
 ============
-You can find the DuckyScript Documentation `here <https://github.com/hak5darren/USB-Rubber-Ducky/wiki/Duckyscript>`_
+You can find the DuckyScript Documentation `here <https://docs.hak5.org/hak5-usb-rubber-ducky/>`_
 
 Dependencies
 =============

--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install ducky
+    circup install adafruit_ducky
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
* replaces the duckyscript link which seems to 404 with a link to the official docs
* updates the `circup install` command to be prefixed by `adafruit_` so it can be used